### PR TITLE
Fix pro generování čísla zásilky pro jiné typy odesilatelů než B a C + malé úpravy

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -17,13 +17,15 @@ class Api extends FakeClient
 {
     /**
      * @param array $packages
+     * @param int|null $customFillingId
      * @throws \Exception
      */
     public function createPackages(
-        array $packages
+        array $packages,
+        $customFillingId = NULL
     ) {
         $filingDate = new \DateTime;
-        $filingId = (date('H') + 1);
+        $filingId = $customFillingId == NULL ? (date('H') + 1) : $customFillingId;
 
         //Close all batches containing packages, delete empty batches
         foreach ($this->getOpenBatches() AS $openBatch) {

--- a/src/Model/WeightedPackageInfo.php
+++ b/src/Model/WeightedPackageInfo.php
@@ -25,7 +25,7 @@ class WeightedPackageInfo
 
     /**
      * WeightedPackageInfo constructor.
-     * @param float $weight
+     * @param float $weight (In KG)
      * @param int|null $height
      * @param int|null $width
      * @param int|null $length

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -53,22 +53,41 @@ class Tools
             default:
             case SenderType::C:
             case SenderType::B:
+                $senderIdNumberCount = 4;
+                $orderIdNumberCount = 5;
+                $modulo = [1, 8, 6, 4, 2, 3, 5, 9, 7];
+                break;
+
             case SenderType::M:
             case SenderType::L:
+                $senderIdNumberCount = 5;
+                $orderIdNumberCount = 4;
+                $modulo = [1, 8, 6, 4, 2, 3, 5, 9, 7];
+                break;
+
             case SenderType::F:
             case SenderType::E:
             case SenderType::P:
+                $senderIdNumberCount = 2;
+                $orderIdNumberCount = 7;
+                $modulo = [1, 8, 6, 4, 2, 3, 5, 9, 7];
+                break;
+
             case SenderType::U:
             case SenderType::T:
+                $senderIdNumberCount = 3;
+                $orderIdNumberCount = 6;
                 $modulo = [1, 8, 6, 4, 2, 3, 5, 9, 7];
                 break;
 
             case SenderType::CZ:
+                $senderIdNumberCount = 0;
+                $orderIdNumberCount = 8;
                 $modulo = [8, 6, 4, 2, 3, 5, 9, 7];
                 break;
         }
 
-        $numberArray = str_split(str_pad($package->getSender()->getId(), 4, '0', STR_PAD_LEFT) . str_pad($package->getSeriesNumberId(), 5, '0', STR_PAD_LEFT));
+        $numberArray = str_split(str_pad($package->getSender()->getId(), $senderIdNumberCount, '0', STR_PAD_LEFT) . str_pad($package->getSeriesNumberId(), $orderIdNumberCount, '0', STR_PAD_LEFT));
         if (count($modulo) != count($numberArray)) {
             throw new \Exception(sprintf('Wrong number array or modulo: %s != %s', count($modulo), count($numberArray)));
         }


### PR DESCRIPTION
Dobrý den Adame,

Děkuji mockrát za sdílení této knihovny a tím i za pomoc v boji s Českou Poštou.

Narazil jsem na problém s výpočtem čísla zásilky pro jiné odesilatele než typu B a C. Procházel jsem dokumentaci a tam jsem našel konstanty pro proporce jednotlivých proměnných v idetifikátoru.

Dále jsem potřeboval určovat externě číslo podání, ale to je drobnost a klidně ji z PR odstraním, pokud je nežádoucí.

S pozdravem
Jan Herzán