### PR TITLE
oprava pro vicekusove zasilky

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -87,7 +87,7 @@ class Api extends FakeClient
                             ($package->getPaymentInfo() ? $package->getPaymentInfo()->getCashOnDeliveryVariableSymbol() : null), //23
                             ($package->getPaymentInfo() ? $package->getPaymentInfo()->getCashOnDeliveryVariableSymbol() : null), //24
                             null, // 25
-                            null, //26
+                            ($package->getPackageCount() > 1 ? $package->getPackageCount() : null), //26
                             null, //27
                             null, //28
                             ($package->getWeightedPackageInfo() ? $package->getWeightedPackageInfo()->getHeight() : null), //29


### PR DESCRIPTION
Nefungovaly mi vicekusove zasilky, toto mi pomohlo.

Pokud jsem to pochopil spravne tak pokud je v csv u baliku nastaveno vicekusova zasilka a je tam pocet zasilek, treba 3, pak ty dalsi 2 zasilky v csv se importuji do te jedne.